### PR TITLE
fix mac os build

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -29,6 +29,12 @@
 	#include <dirent.h>
 
 	#if defined(CONF_PLATFORM_MACOSX)
+		// some lock and pthread functions are already defined in headers
+		// included from Carbon.h
+		// this prevents having duplicate definitions of those
+		#define _lock_set_user_
+		#define _task_user_
+
 		#include <Carbon/Carbon.h>
 	#endif
 	


### PR DESCRIPTION
Fixes most of the build for me on OSX 10.10.1 (still have to do CPLUS_INCLUDE_PATH=/opt/X11/include ./bam ...).
Hopefully wouldn't break build for older OSX versions, I have no way to test :/