### PR TITLE
Client side prediction of weak/strong hook

### DIFF
--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -329,6 +329,8 @@ public:
 	CWeaponData *GetWeaponData(int Tick) { return &m_aWeaponData[((Tick%150)+150)%150]; }
 	CWeaponData *FindWeaponData(int TargetTick);
 
+	void FindWeaker(bool IsWeaker[2][MAX_CLIENTS]);
+
 private:
 
 	bool m_DDRaceMsgSent[2];


### PR DESCRIPTION
Sometimes the client will predict the wrong hook strength, and this is an attempt to correct that, by making the client detect if it has strong/weak.

It only attempts to detect weak/strong between the client and other players (I think it would be possible to detect it between every player, but it would be more complex and require more work). Also, since the detection works by looking at past interaction between you and other players, there is a small delay before the detection takes effect. This is slightly noticable the first time you hook another player, but after that the predicted hook strength should be correct until one of you respawns.

I didnt add a config flag for it and just made it activated when antiping_players is active (not sure if that is the best solution)