### PR TITLE
Fix progress bar overflow and Abort segfault

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -310,6 +310,7 @@ CClient::CClient() : m_DemoPlayer(&m_SnapshotDelta)
 	// map download
 	m_aMapdownloadFilename[0] = 0;
 	m_aMapdownloadName[0] = 0;
+	m_pMapdownloadTask = 0;
 	m_MapdownloadFile = 0;
 	m_MapdownloadChunk = 0;
 	m_MapdownloadCrc = 0;
@@ -735,6 +736,8 @@ void CClient::DisconnectWithReason(const char *pReason)
 
 	// disable all downloads
 	m_MapdownloadChunk = 0;
+	if(m_pMapdownloadTask)
+		m_pMapdownloadTask->Abort();
 	if(m_MapdownloadFile)
 		io_close(m_MapdownloadFile);
 	m_MapdownloadFile = 0;
@@ -2420,13 +2423,20 @@ void CClient::Update()
 
 	// pump the network
 	PumpNetwork();
-	if(m_pMapdownloadTask){
+	if(m_pMapdownloadTask)
+	{
 		if(m_pMapdownloadTask->State() == CFetchTask::STATE_DONE)
 			FinishMapDownload();
-		else if(m_pMapdownloadTask->State() == CFetchTask::STATE_ERROR){
+		else if(m_pMapdownloadTask->State() == CFetchTask::STATE_ERROR)
+		{
 			dbg_msg("webdl", "HTTP failed falling back to gameserver.");
 			ResetMapDownload();
 			SendMapRequest();
+		}
+		else if(m_pMapdownloadTask->State() == CFetchTask::STATE_ABORTED)
+		{
+			delete m_pMapdownloadTask;
+			m_pMapdownloadTask = 0;
 		}
 	}
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1555,6 +1555,8 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					m_MapdownloadTotalsize = MapSize;
 					m_MapdownloadAmount = 0;
 
+					ResetMapDownload();
+
 					if(g_Config.m_ClHttpMapDownload)
 					{
 						char aUrl[256];
@@ -1563,10 +1565,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 						Fetcher()->QueueAdd(m_pMapdownloadTask, aUrl, m_aMapdownloadFilename, IStorage::TYPE_SAVE);
 					}
 					else
-					{
-						ResetMapDownload();
 						SendMapRequest();
-					}
 				}
 			}
 		}

--- a/src/engine/client/fetcher.cpp
+++ b/src/engine/client/fetcher.cpp
@@ -146,8 +146,7 @@ int CFetcher::ProgressCallback(void *pUser, double DlTotal, double DlCurr, doubl
 	CFetchTask *pTask = (CFetchTask *)pUser;
 	//dbg_msg("fetcher", "DlCurr:%f, DlTotal:%f", DlCurr, DlTotal);
 	pTask->m_Current = DlCurr;
-	if(!pTask->m_Size)
-		pTask->m_Size = DlTotal;
+	pTask->m_Size = DlTotal;
 	pTask->m_Progress = (100 * DlCurr) / (DlTotal ? DlTotal : 1);
 	if(pTask->m_pfnProgressCallback)
 		pTask->m_pfnProgressCallback(pTask, pTask->m_pUser);

--- a/src/engine/client/fetcher.cpp
+++ b/src/engine/client/fetcher.cpp
@@ -40,6 +40,7 @@ void CFetcher::QueueAdd(CFetchTask *pTask, const char *pUrl, const char *pDest, 
 	pTask->m_pfnCompCallback = pfnCompCb;
 	pTask->m_pUser = pUser;
 	pTask->m_Size = pTask->m_Progress = 0;
+	pTask->m_Abort = false;
 
 	lock_wait(m_Lock);
 	if(!m_pFirst)
@@ -122,10 +123,11 @@ bool CFetcher::FetchFile(CFetchTask *pTask)
 
 	dbg_msg("fetcher", "Downloading %s", pTask->m_pDest);
 	pTask->m_State = CFetchTask::STATE_RUNNING;
-	if(curl_easy_perform(m_pHandle) != CURLE_OK)
+	int ret = curl_easy_perform(m_pHandle);
+	if(ret != CURLE_OK)
 	{
 		dbg_msg("fetcher", "Task failed. libcurl error: %s", aErr);
-		pTask->m_State = CFetchTask::STATE_ERROR;
+		pTask->m_State = (ret == CURLE_ABORTED_BY_CALLBACK) ? CFetchTask::STATE_ABORTED : CFetchTask::STATE_ERROR;
 		return false;
 	}
 	io_close(File);
@@ -150,5 +152,5 @@ int CFetcher::ProgressCallback(void *pUser, double DlTotal, double DlCurr, doubl
 	pTask->m_Progress = (100 * DlCurr) / (DlTotal ? DlTotal : 1);
 	if(pTask->m_pfnProgressCallback)
 		pTask->m_pfnProgressCallback(pTask, pTask->m_pUser);
-	return 0;
+	return pTask->m_Abort ? -1 : 0;
 }

--- a/src/engine/fetcher.h
+++ b/src/engine/fetcher.h
@@ -25,6 +25,7 @@ class CFetchTask
 	double m_Size;
 	int m_Progress;
 	int m_State;
+	bool m_Abort;
 public:	
 	CFetchTask();
 
@@ -34,6 +35,7 @@ public:
 		STATE_QUEUED,
 		STATE_RUNNING,
 		STATE_DONE,
+		STATE_ABORTED,
 	};
 
 	const double Current() const { return m_Current; };
@@ -41,6 +43,8 @@ public:
 	const int Progress() const { return m_Progress; };
 	const int State() const { return m_State; };
 	const char *Dest() const { return m_pDest; };
+
+	void Abort() { m_Abort = true; };
 };
 
 class IFetcher : public IInterface
@@ -48,7 +52,7 @@ class IFetcher : public IInterface
 	MACRO_INTERFACE("fetcher", 0)
 public:
 	virtual bool Init() = 0;
-	virtual void QueueAdd(CFetchTask *pTask, const char *pUrl, const char *pDest, int StorageType = 2, void *pUser = 0, COMPFUNC pfnCompCb = 0, PROGFUNC pfnProgCb = 0) = 0;
+	virtual void QueueAdd(CFetchTask *pTask,const char *pUrl, const char *pDest, int StorageType = 2, void *pUser = 0, COMPFUNC pfnCompCb = 0, PROGFUNC pfnProgCb = 0) = 0;
 	virtual long HTTPResponse(const char *pUrl) = 0;
 };
 


### PR DESCRIPTION
A HTTP download following a vanilla download caused the progress bar to overflow as libcurl sends old data to the callback in the beginning of the download for some reason.

Also fixed a Segmentation Fault when the task object is deleted without aborting first.