### PR TITLE
Fix bug when reading reading chunks with a tick delta of 0

### DIFF
--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -152,8 +152,9 @@ enum
 {
 	CHUNKTYPEFLAG_TICKMARKER = 0x80,
 	CHUNKTICKFLAG_KEYFRAME = 0x40, // only when tickmarker is set
+	CHUNKTICKFLAG_TICK_COMPRESSED = 0x20, // when we store the tick value in the first chunk
 
-	CHUNKMASK_TICK = 0x3f,
+	CHUNKMASK_TICK = 0x1f,
 	CHUNKMASK_TYPE = 0x60,
 	CHUNKMASK_SIZE = 0x1f,
 
@@ -166,7 +167,7 @@ enum
 
 void CDemoRecorder::WriteTickMarker(int Tick, int Keyframe)
 {
-	if(m_LastTickMarker == -1 || Tick-m_LastTickMarker > 63 || Keyframe)
+	if(m_LastTickMarker == -1 || Tick-m_LastTickMarker > CHUNKMASK_TICK || Keyframe)
 	{
 		unsigned char aChunk[5];
 		aChunk[0] = CHUNKTYPEFLAG_TICKMARKER;
@@ -183,7 +184,7 @@ void CDemoRecorder::WriteTickMarker(int Tick, int Keyframe)
 	else
 	{
 		unsigned char aChunk[1];
-		aChunk[0] = CHUNKTYPEFLAG_TICKMARKER | (Tick-m_LastTickMarker);
+		aChunk[0] = CHUNKTYPEFLAG_TICKMARKER | CHUNKTICKFLAG_TICK_COMPRESSED | (Tick-m_LastTickMarker);
 		io_write(m_File, aChunk, sizeof(aChunk));
 	}
 
@@ -371,19 +372,19 @@ int CDemoPlayer::ReadChunkHeader(int *pType, int *pSize, int *pTick)
 	if(Chunk&CHUNKTYPEFLAG_TICKMARKER)
 	{
 		// decode tick marker
-		int Tickdelta = Chunk&(CHUNKMASK_TICK);
 		*pType = Chunk&(CHUNKTYPEFLAG_TICKMARKER|CHUNKTICKFLAG_KEYFRAME);
 
-		if(Tickdelta == 0)
+		if(Chunk&(CHUNKTICKFLAG_TICK_COMPRESSED))
+		{
+			int Tickdelta = Chunk&(CHUNKMASK_TICK);
+			*pTick += Tickdelta;
+		}
+		else
 		{
 			unsigned char aTickdata[4];
 			if(io_read(m_File, aTickdata, sizeof(aTickdata)) != sizeof(aTickdata))
 				return -1;
 			*pTick = (aTickdata[0]<<24) | (aTickdata[1]<<16) | (aTickdata[2]<<8) | aTickdata[3];
-		}
-		else
-		{
-			*pTick += Tickdelta;
 		}
 
 	}


### PR DESCRIPTION
Fixing some incorrectly interpreted demo chunks via an additional flag.
Probably not compatible with older client!

```
[12:41]	EastByte	I'm pretty sure there is a delta tickmarker of zero in the demo
[12:41]	EastByte	and this causes the demo player to read 4 more bytes for extended size
[12:42]	EastByte	by checking CHUNKTICKFLAG_KEYFRAME instead of deltatick==0 the demo works
[12:44]	BeaR_	will take a look later (:
[12:44]	EastByte	:3
[13:39]	BeaR_	hm looks like the same bug, which causes this segfault https://github.com/def-/ddnet/issues/140#
[13:41]	BeaR_	a tick delta of 0 would a possible
[13:41]	BeaR_	aChunk[0] = CHUNKTYPEFLAG_TICKMARKER | (Tick-m_LastTickMarker)
[13:41]	BeaR_	and checking for CHUNKMASK_TICK would result in tickdetla 0 for Tick-m_LastTickMarker == 0
[13:43]	BeaR_	using the keyframe flag will work but it's not how it should be solved
[13:44]	BeaR_	praise 0 documentation ):
[13:48]	BeaR_	[13:41]BeaR_: a tick delta of 0 would a possible lol, I meant, a tick delta of 0 is a possible source of this bug
[13:56]	EastByte	maybe we can add another flag?
[13:56]	EastByte	or simply disallow adding of delta 0
[13:58]	EastByte	BeaR_: do you think a delta tickmarker of >63 is even possible?
[13:59]	BeaR_	y
[14:02]	EastByte	to play older demos affected by this bug is even more complicated
[14:03]	EastByte	one way would be to check for invalid tickmarkers and correct them afterwards
[14:03]	BeaR_	not that easy /:
[14:04]	BeaR_	you only know that it's invalid if the resulting tickvalue is wrong
[14:05]	EastByte	needs some heuristic I guess
[14:06]	BeaR_	hm looks like there is no additional space for an extra flag .-.
[14:06]	EastByte	to assume that full tickmarkers always diff by one second
[14:06]	EastByte	5 seconds*
[14:07]	BeaR_	that might work
[14:07]	EastByte	for me the diff always was TICKSPEED*5 and + 2
[14:07]	EastByte	probably because of a delta tick
[14:07]	BeaR_	well we could shave one bit from CHUNKMASK_TICK
[14:08]	EastByte	yea shouldn't be a problem
```