### PR TITLE
fix missing size_t definition on mac

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -9,6 +9,7 @@
 #define BASE_SYSTEM_H
 
 #include "detect.h"
+#include "stddef.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
not sure if the right header but it works for me
cc @heinrich5991 