### PR TITLE
Winapi MoveFile allows moving the client.

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1729,9 +1729,14 @@ int fs_remove(const char *filename)
 }
 
 int fs_rename(const char *oldname, const char *newname)
-{
+{	
+#if defined(CONF_FAMILY_WINDOWS)
+	if(MoveFile(oldname, newname) != 0)
+		return 1;
+#else
 	if(rename(oldname, newname) != 0)
 		return 1;
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
WinAPI MoveFile() allows moving running executables unlike libc rename().