### PR TITLE
Reduce amount of drawcalls when using triangles instead of quads

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -336,22 +336,18 @@ void CCommandProcessorFragment_OpenGL::Cmd_Render(const CCommandBuffer::SCommand
 	switch(pCommand->m_PrimType)
 	{
 	case CCommandBuffer::PRIMTYPE_QUADS:
-#if !defined(__ANDROID__)
-		if(g_Config.m_GfxQuadsAsTriangles)
-#endif
-		{
-			for( unsigned i = 0, j = pCommand->m_PrimCount; i < j; i++ )
-				glDrawArrays(GL_TRIANGLE_FAN, i*4, 4);
-		}
-#if !defined(__ANDROID__)
-		else
-		{
-			glDrawArrays(GL_QUADS, 0, pCommand->m_PrimCount*4);
-		}
+#if defined(__ANDROID__)
+		for( unsigned i = 0, j = pCommand->m_PrimCount; i < j; i++ )
+			glDrawArrays(GL_TRIANGLE_FAN, i*4, 4);
+#else
+		glDrawArrays(GL_QUADS, 0, pCommand->m_PrimCount*4);
 #endif
 		break;
 	case CCommandBuffer::PRIMTYPE_LINES:
 		glDrawArrays(GL_LINES, 0, pCommand->m_PrimCount*2);
+		break;
+	case CCommandBuffer::PRIMTYPE_TRIANGLES:
+		glDrawArrays(GL_TRIANGLES, 0, pCommand->m_PrimCount*3);
 		break;
 	default:
 		dbg_msg("render", "unknown primtype %d\n", pCommand->m_Cmd);

--- a/src/engine/client/graphics.cpp
+++ b/src/engine/client/graphics.cpp
@@ -105,18 +105,14 @@ void CGraphics_OpenGL::Flush()
 	{
 		if(m_Drawing == DRAWING_QUADS)
 		{
-#if !defined(__ANDROID__)
+#if defined(__ANDROID__)
+			for( unsigned i = 0, j = m_NumVertices; i < j; i += 4 )
+				glDrawArrays(GL_TRIANGLE_FAN, i, 4);
+#else
 			if(g_Config.m_GfxQuadsAsTriangles)
-#endif
-			{
-				for( unsigned i = 0, j = m_NumVertices; i < j; i += 4 )
-					glDrawArrays(GL_TRIANGLE_FAN, i, 4);
-			}
-#if !defined(__ANDROID__)
+				glDrawArrays(GL_TRIANGLES, 0, m_NumVertices);
 			else
-			{
 				glDrawArrays(GL_QUADS, 0, m_NumVertices);
-			}
 #endif
 		}
 		else if(m_Drawing == DRAWING_LINES)
@@ -134,14 +130,14 @@ void CGraphics_OpenGL::AddVertices(int Count)
 		Flush();
 }
 
-void CGraphics_OpenGL::Rotate4(const CPoint &rCenter, CVertex *pPoints)
+void CGraphics_OpenGL::Rotate(const CPoint &rCenter, CVertex *pPoints, int NumPoints)
 {
 	float c = cosf(m_Rotation);
 	float s = sinf(m_Rotation);
 	float x, y;
 	int i;
 
-	for(i = 0; i < 4; i++)
+	for(i = 0; i < NumPoints; i++)
 	{
 		x = pPoints[i].m_Pos.x - rCenter.x;
 		y = pPoints[i].m_Pos.y - rCenter.y;
@@ -674,68 +670,158 @@ void CGraphics_OpenGL::QuadsDrawTL(const CQuadItem *pArray, int Num)
 
 	dbg_assert(m_Drawing == DRAWING_QUADS, "called Graphics()->QuadsDrawTL without begin");
 
-	for(int i = 0; i < Num; ++i)
+	if(g_Config.m_GfxQuadsAsTriangles)
 	{
-		m_aVertices[m_NumVertices + 4*i].m_Pos.x = pArray[i].m_X;
-		m_aVertices[m_NumVertices + 4*i].m_Pos.y = pArray[i].m_Y;
-		m_aVertices[m_NumVertices + 4*i].m_Tex = m_aTexture[0];
-		m_aVertices[m_NumVertices + 4*i].m_Color = m_aColor[0];
-
-		m_aVertices[m_NumVertices + 4*i + 1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
-		m_aVertices[m_NumVertices + 4*i + 1].m_Pos.y = pArray[i].m_Y;
-		m_aVertices[m_NumVertices + 4*i + 1].m_Tex = m_aTexture[1];
-		m_aVertices[m_NumVertices + 4*i + 1].m_Color = m_aColor[1];
-
-		m_aVertices[m_NumVertices + 4*i + 2].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
-		m_aVertices[m_NumVertices + 4*i + 2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
-		m_aVertices[m_NumVertices + 4*i + 2].m_Tex = m_aTexture[2];
-		m_aVertices[m_NumVertices + 4*i + 2].m_Color = m_aColor[2];
-
-		m_aVertices[m_NumVertices + 4*i + 3].m_Pos.x = pArray[i].m_X;
-		m_aVertices[m_NumVertices + 4*i + 3].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
-		m_aVertices[m_NumVertices + 4*i + 3].m_Tex = m_aTexture[3];
-		m_aVertices[m_NumVertices + 4*i + 3].m_Color = m_aColor[3];
-
-		if(m_Rotation != 0)
+		for(int i = 0; i < Num; ++i)
 		{
-			Center.x = pArray[i].m_X + pArray[i].m_Width/2;
-			Center.y = pArray[i].m_Y + pArray[i].m_Height/2;
+			// first triangle
+			m_aVertices[m_NumVertices + 6*i].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 6*i].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 6*i].m_Tex = m_aTexture[0];
+			m_aVertices[m_NumVertices + 6*i].m_Color = m_aColor[0];
 
-			Rotate4(Center, &m_aVertices[m_NumVertices + 4*i]);
+			m_aVertices[m_NumVertices + 6*i + 1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 6*i + 1].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 6*i + 1].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 6*i + 1].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 6*i + 2].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 6*i + 2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 6*i + 2].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 6*i + 2].m_Color = m_aColor[3];
+
+			// second triangle
+			m_aVertices[m_NumVertices + 6*i + 3].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 6*i + 3].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 6*i + 3].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 6*i + 3].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 6*i + 4].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 6*i + 4].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 6*i + 4].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 6*i + 4].m_Color = m_aColor[2];
+
+			m_aVertices[m_NumVertices + 6*i + 5].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 6*i + 5].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 6*i + 5].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 6*i + 5].m_Color = m_aColor[3];
+
+			if(m_Rotation != 0)
+			{
+				Center.x = pArray[i].m_X + pArray[i].m_Width/2;
+				Center.y = pArray[i].m_Y + pArray[i].m_Height/2;
+
+				Rotate(Center, &m_aVertices[m_NumVertices + 6*i], 6);
+			}
 		}
-	}
 
-	AddVertices(4*Num);
+		AddVertices(3*2*Num);
+	}
+	else
+	{
+		for(int i = 0; i < Num; ++i)
+		{
+			m_aVertices[m_NumVertices + 4*i].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 4*i].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 4*i].m_Tex = m_aTexture[0];
+			m_aVertices[m_NumVertices + 4*i].m_Color = m_aColor[0];
+
+			m_aVertices[m_NumVertices + 4*i + 1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 4*i + 1].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 4*i + 1].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 4*i + 1].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 4*i + 2].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 4*i + 2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 4*i + 2].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 4*i + 2].m_Color = m_aColor[2];
+
+			m_aVertices[m_NumVertices + 4*i + 3].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 4*i + 3].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 4*i + 3].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 4*i + 3].m_Color = m_aColor[3];
+
+			if(m_Rotation != 0)
+			{
+				Center.x = pArray[i].m_X + pArray[i].m_Width/2;
+				Center.y = pArray[i].m_Y + pArray[i].m_Height/2;
+
+				Rotate(Center, &m_aVertices[m_NumVertices + 4*i], 4);
+			}
+		}
+
+		AddVertices(4*Num);
+	}
 }
 
 void CGraphics_OpenGL::QuadsDrawFreeform(const CFreeformItem *pArray, int Num)
 {
 	dbg_assert(m_Drawing == DRAWING_QUADS, "called Graphics()->QuadsDrawFreeform without begin");
 
-	for(int i = 0; i < Num; ++i)
+	if(g_Config.m_GfxQuadsAsTriangles)
 	{
-		m_aVertices[m_NumVertices + 4*i].m_Pos.x = pArray[i].m_X0;
-		m_aVertices[m_NumVertices + 4*i].m_Pos.y = pArray[i].m_Y0;
-		m_aVertices[m_NumVertices + 4*i].m_Tex = m_aTexture[0];
-		m_aVertices[m_NumVertices + 4*i].m_Color = m_aColor[0];
+		for(int i = 0; i < Num; ++i)
+		{
+			m_aVertices[m_NumVertices + 6*i].m_Pos.x = pArray[i].m_X0;
+			m_aVertices[m_NumVertices + 6*i].m_Pos.y = pArray[i].m_Y0;
+			m_aVertices[m_NumVertices + 6*i].m_Tex = m_aTexture[0];
+			m_aVertices[m_NumVertices + 6*i].m_Color = m_aColor[0];
 
-		m_aVertices[m_NumVertices + 4*i + 1].m_Pos.x = pArray[i].m_X1;
-		m_aVertices[m_NumVertices + 4*i + 1].m_Pos.y = pArray[i].m_Y1;
-		m_aVertices[m_NumVertices + 4*i + 1].m_Tex = m_aTexture[1];
-		m_aVertices[m_NumVertices + 4*i + 1].m_Color = m_aColor[1];
+			m_aVertices[m_NumVertices + 6*i + 1].m_Pos.x = pArray[i].m_X1;
+			m_aVertices[m_NumVertices + 6*i + 1].m_Pos.y = pArray[i].m_Y1;
+			m_aVertices[m_NumVertices + 6*i + 1].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 6*i + 1].m_Color = m_aColor[1];
 
-		m_aVertices[m_NumVertices + 4*i + 2].m_Pos.x = pArray[i].m_X3;
-		m_aVertices[m_NumVertices + 4*i + 2].m_Pos.y = pArray[i].m_Y3;
-		m_aVertices[m_NumVertices + 4*i + 2].m_Tex = m_aTexture[3];
-		m_aVertices[m_NumVertices + 4*i + 2].m_Color = m_aColor[3];
+			m_aVertices[m_NumVertices + 6*i + 2].m_Pos.x = pArray[i].m_X2;
+			m_aVertices[m_NumVertices + 6*i + 2].m_Pos.y = pArray[i].m_Y2;
+			m_aVertices[m_NumVertices + 6*i + 2].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 6*i + 2].m_Color = m_aColor[2];
 
-		m_aVertices[m_NumVertices + 4*i + 3].m_Pos.x = pArray[i].m_X2;
-		m_aVertices[m_NumVertices + 4*i + 3].m_Pos.y = pArray[i].m_Y2;
-		m_aVertices[m_NumVertices + 4*i + 3].m_Tex = m_aTexture[2];
-		m_aVertices[m_NumVertices + 4*i + 3].m_Color = m_aColor[2];
+			m_aVertices[m_NumVertices + 6*i + 3].m_Pos.x = pArray[i].m_X1;
+			m_aVertices[m_NumVertices + 6*i + 3].m_Pos.y = pArray[i].m_Y1;
+			m_aVertices[m_NumVertices + 6*i + 3].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 6*i + 3].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 6*i + 4].m_Pos.x = pArray[i].m_X3;
+			m_aVertices[m_NumVertices + 6*i + 4].m_Pos.y = pArray[i].m_Y3;
+			m_aVertices[m_NumVertices + 6*i + 4].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 6*i + 4].m_Color = m_aColor[3];
+
+			m_aVertices[m_NumVertices + 6*i + 5].m_Pos.x = pArray[i].m_X2;
+			m_aVertices[m_NumVertices + 6*i + 5].m_Pos.y = pArray[i].m_Y2;
+			m_aVertices[m_NumVertices + 6*i + 5].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 6*i + 5].m_Color = m_aColor[2];
+		}
+
+		AddVertices(3*2*Num);
 	}
+	else
+	{
+		for(int i = 0; i < Num; ++i)
+		{
+			m_aVertices[m_NumVertices + 4*i].m_Pos.x = pArray[i].m_X0;
+			m_aVertices[m_NumVertices + 4*i].m_Pos.y = pArray[i].m_Y0;
+			m_aVertices[m_NumVertices + 4*i].m_Tex = m_aTexture[0];
+			m_aVertices[m_NumVertices + 4*i].m_Color = m_aColor[0];
 
-	AddVertices(4*Num);
+			m_aVertices[m_NumVertices + 4*i + 1].m_Pos.x = pArray[i].m_X1;
+			m_aVertices[m_NumVertices + 4*i + 1].m_Pos.y = pArray[i].m_Y1;
+			m_aVertices[m_NumVertices + 4*i + 1].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 4*i + 1].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 4*i + 2].m_Pos.x = pArray[i].m_X3;
+			m_aVertices[m_NumVertices + 4*i + 2].m_Pos.y = pArray[i].m_Y3;
+			m_aVertices[m_NumVertices + 4*i + 2].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 4*i + 2].m_Color = m_aColor[3];
+
+			m_aVertices[m_NumVertices + 4*i + 3].m_Pos.x = pArray[i].m_X2;
+			m_aVertices[m_NumVertices + 4*i + 3].m_Pos.y = pArray[i].m_Y2;
+			m_aVertices[m_NumVertices + 4*i + 3].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 4*i + 3].m_Color = m_aColor[2];
+		}
+
+		AddVertices(4*Num);
+	}
 }
 
 void CGraphics_OpenGL::QuadsText(float x, float y, float Size, const char *pText)

--- a/src/engine/client/graphics.h
+++ b/src/engine/client/graphics.h
@@ -64,7 +64,7 @@ protected:
 
 	void Flush();
 	void AddVertices(int Count);
-	void Rotate4(const CPoint &rCenter, CVertex *pPoints);
+	void Rotate(const CPoint &rCenter, CVertex *pPoints, int NumPoints);
 
 	static unsigned char Sample(int w, int h, const unsigned char *pData, int u, int v, int Offset, int ScaleW, int ScaleH, int Bpp);
 	static unsigned char *Rescale(int Width, int Height, int NewWidth, int NewHeight, int Format, const unsigned char *pData);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -59,8 +59,16 @@ void CGraphics_Threaded::FlushVertices()
 
 	if(m_Drawing == DRAWING_QUADS)
 	{
-		Cmd.m_PrimType = CCommandBuffer::PRIMTYPE_QUADS;
-		Cmd.m_PrimCount = NumVerts/4;
+		if(g_Config.m_GfxQuadsAsTriangles)
+		{
+			Cmd.m_PrimType = CCommandBuffer::PRIMTYPE_TRIANGLES;
+			Cmd.m_PrimCount = NumVerts/3;
+		}
+		else
+		{
+			Cmd.m_PrimType = CCommandBuffer::PRIMTYPE_QUADS;
+			Cmd.m_PrimCount = NumVerts/4;
+		}	
 	}
 	else if(m_Drawing == DRAWING_LINES)
 	{
@@ -114,14 +122,14 @@ void CGraphics_Threaded::AddVertices(int Count)
 		FlushVertices();
 }
 
-void CGraphics_Threaded::Rotate4(const CCommandBuffer::SPoint &rCenter, CCommandBuffer::SVertex *pPoints)
+void CGraphics_Threaded::Rotate(const CCommandBuffer::SPoint &rCenter, CCommandBuffer::SVertex *pPoints, int NumPoints)
 {
 	float c = cosf(m_Rotation);
 	float s = sinf(m_Rotation);
 	float x, y;
 	int i;
 
-	for(i = 0; i < 4; i++)
+	for(i = 0; i < NumPoints; i++)
 	{
 		x = pPoints[i].m_Pos.x - rCenter.x;
 		y = pPoints[i].m_Pos.y - rCenter.y;
@@ -588,68 +596,158 @@ void CGraphics_Threaded::QuadsDrawTL(const CQuadItem *pArray, int Num)
 
 	dbg_assert(m_Drawing == DRAWING_QUADS, "called Graphics()->QuadsDrawTL without begin");
 
-	for(int i = 0; i < Num; ++i)
+	if(g_Config.m_GfxQuadsAsTriangles)
 	{
-		m_aVertices[m_NumVertices + 4*i].m_Pos.x = pArray[i].m_X;
-		m_aVertices[m_NumVertices + 4*i].m_Pos.y = pArray[i].m_Y;
-		m_aVertices[m_NumVertices + 4*i].m_Tex = m_aTexture[0];
-		m_aVertices[m_NumVertices + 4*i].m_Color = m_aColor[0];
-
-		m_aVertices[m_NumVertices + 4*i + 1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
-		m_aVertices[m_NumVertices + 4*i + 1].m_Pos.y = pArray[i].m_Y;
-		m_aVertices[m_NumVertices + 4*i + 1].m_Tex = m_aTexture[1];
-		m_aVertices[m_NumVertices + 4*i + 1].m_Color = m_aColor[1];
-
-		m_aVertices[m_NumVertices + 4*i + 2].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
-		m_aVertices[m_NumVertices + 4*i + 2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
-		m_aVertices[m_NumVertices + 4*i + 2].m_Tex = m_aTexture[2];
-		m_aVertices[m_NumVertices + 4*i + 2].m_Color = m_aColor[2];
-
-		m_aVertices[m_NumVertices + 4*i + 3].m_Pos.x = pArray[i].m_X;
-		m_aVertices[m_NumVertices + 4*i + 3].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
-		m_aVertices[m_NumVertices + 4*i + 3].m_Tex = m_aTexture[3];
-		m_aVertices[m_NumVertices + 4*i + 3].m_Color = m_aColor[3];
-
-		if(m_Rotation != 0)
+		for(int i = 0; i < Num; ++i)
 		{
-			Center.x = pArray[i].m_X + pArray[i].m_Width/2;
-			Center.y = pArray[i].m_Y + pArray[i].m_Height/2;
+			// first triangle
+			m_aVertices[m_NumVertices + 6*i].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 6*i].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 6*i].m_Tex = m_aTexture[0];
+			m_aVertices[m_NumVertices + 6*i].m_Color = m_aColor[0];
 
-			Rotate4(Center, &m_aVertices[m_NumVertices + 4*i]);
+			m_aVertices[m_NumVertices + 6*i + 1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 6*i + 1].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 6*i + 1].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 6*i + 1].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 6*i + 2].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 6*i + 2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 6*i + 2].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 6*i + 2].m_Color = m_aColor[3];
+
+			// second triangle
+			m_aVertices[m_NumVertices + 6*i + 3].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 6*i + 3].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 6*i + 3].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 6*i + 3].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 6*i + 4].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 6*i + 4].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 6*i + 4].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 6*i + 4].m_Color = m_aColor[2];
+
+			m_aVertices[m_NumVertices + 6*i + 5].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 6*i + 5].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 6*i + 5].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 6*i + 5].m_Color = m_aColor[3];
+
+			if(m_Rotation != 0)
+			{
+				Center.x = pArray[i].m_X + pArray[i].m_Width/2;
+				Center.y = pArray[i].m_Y + pArray[i].m_Height/2;
+
+				Rotate(Center, &m_aVertices[m_NumVertices + 6*i], 6);
+			}
 		}
-	}
 
-	AddVertices(4*Num);
+		AddVertices(3*2*Num);
+	}
+	else
+	{
+		for(int i = 0; i < Num; ++i)
+		{
+			m_aVertices[m_NumVertices + 4*i].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 4*i].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 4*i].m_Tex = m_aTexture[0];
+			m_aVertices[m_NumVertices + 4*i].m_Color = m_aColor[0];
+
+			m_aVertices[m_NumVertices + 4*i + 1].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 4*i + 1].m_Pos.y = pArray[i].m_Y;
+			m_aVertices[m_NumVertices + 4*i + 1].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 4*i + 1].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 4*i + 2].m_Pos.x = pArray[i].m_X + pArray[i].m_Width;
+			m_aVertices[m_NumVertices + 4*i + 2].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 4*i + 2].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 4*i + 2].m_Color = m_aColor[2];
+
+			m_aVertices[m_NumVertices + 4*i + 3].m_Pos.x = pArray[i].m_X;
+			m_aVertices[m_NumVertices + 4*i + 3].m_Pos.y = pArray[i].m_Y + pArray[i].m_Height;
+			m_aVertices[m_NumVertices + 4*i + 3].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 4*i + 3].m_Color = m_aColor[3];
+
+			if(m_Rotation != 0)
+			{
+				Center.x = pArray[i].m_X + pArray[i].m_Width/2;
+				Center.y = pArray[i].m_Y + pArray[i].m_Height/2;
+
+				Rotate(Center, &m_aVertices[m_NumVertices + 4*i], 4);
+			}
+		}
+
+		AddVertices(4*Num);
+	}
 }
 
 void CGraphics_Threaded::QuadsDrawFreeform(const CFreeformItem *pArray, int Num)
 {
 	dbg_assert(m_Drawing == DRAWING_QUADS, "called Graphics()->QuadsDrawFreeform without begin");
 
-	for(int i = 0; i < Num; ++i)
+	if(g_Config.m_GfxQuadsAsTriangles)
 	{
-		m_aVertices[m_NumVertices + 4*i].m_Pos.x = pArray[i].m_X0;
-		m_aVertices[m_NumVertices + 4*i].m_Pos.y = pArray[i].m_Y0;
-		m_aVertices[m_NumVertices + 4*i].m_Tex = m_aTexture[0];
-		m_aVertices[m_NumVertices + 4*i].m_Color = m_aColor[0];
+		for(int i = 0; i < Num; ++i)
+		{
+			m_aVertices[m_NumVertices + 6*i].m_Pos.x = pArray[i].m_X0;
+			m_aVertices[m_NumVertices + 6*i].m_Pos.y = pArray[i].m_Y0;
+			m_aVertices[m_NumVertices + 6*i].m_Tex = m_aTexture[0];
+			m_aVertices[m_NumVertices + 6*i].m_Color = m_aColor[0];
 
-		m_aVertices[m_NumVertices + 4*i + 1].m_Pos.x = pArray[i].m_X1;
-		m_aVertices[m_NumVertices + 4*i + 1].m_Pos.y = pArray[i].m_Y1;
-		m_aVertices[m_NumVertices + 4*i + 1].m_Tex = m_aTexture[1];
-		m_aVertices[m_NumVertices + 4*i + 1].m_Color = m_aColor[1];
+			m_aVertices[m_NumVertices + 6*i + 1].m_Pos.x = pArray[i].m_X1;
+			m_aVertices[m_NumVertices + 6*i + 1].m_Pos.y = pArray[i].m_Y1;
+			m_aVertices[m_NumVertices + 6*i + 1].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 6*i + 1].m_Color = m_aColor[1];
 
-		m_aVertices[m_NumVertices + 4*i + 2].m_Pos.x = pArray[i].m_X3;
-		m_aVertices[m_NumVertices + 4*i + 2].m_Pos.y = pArray[i].m_Y3;
-		m_aVertices[m_NumVertices + 4*i + 2].m_Tex = m_aTexture[3];
-		m_aVertices[m_NumVertices + 4*i + 2].m_Color = m_aColor[3];
+			m_aVertices[m_NumVertices + 6*i + 2].m_Pos.x = pArray[i].m_X2;
+			m_aVertices[m_NumVertices + 6*i + 2].m_Pos.y = pArray[i].m_Y2;
+			m_aVertices[m_NumVertices + 6*i + 2].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 6*i + 2].m_Color = m_aColor[2];
 
-		m_aVertices[m_NumVertices + 4*i + 3].m_Pos.x = pArray[i].m_X2;
-		m_aVertices[m_NumVertices + 4*i + 3].m_Pos.y = pArray[i].m_Y2;
-		m_aVertices[m_NumVertices + 4*i + 3].m_Tex = m_aTexture[2];
-		m_aVertices[m_NumVertices + 4*i + 3].m_Color = m_aColor[2];
+			m_aVertices[m_NumVertices + 6*i + 3].m_Pos.x = pArray[i].m_X1;
+			m_aVertices[m_NumVertices + 6*i + 3].m_Pos.y = pArray[i].m_Y1;
+			m_aVertices[m_NumVertices + 6*i + 3].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 6*i + 3].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 6*i + 4].m_Pos.x = pArray[i].m_X3;
+			m_aVertices[m_NumVertices + 6*i + 4].m_Pos.y = pArray[i].m_Y3;
+			m_aVertices[m_NumVertices + 6*i + 4].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 6*i + 4].m_Color = m_aColor[3];
+
+			m_aVertices[m_NumVertices + 6*i + 5].m_Pos.x = pArray[i].m_X2;
+			m_aVertices[m_NumVertices + 6*i + 5].m_Pos.y = pArray[i].m_Y2;
+			m_aVertices[m_NumVertices + 6*i + 5].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 6*i + 5].m_Color = m_aColor[2];
+		}
+
+		AddVertices(3*2*Num);
 	}
+	else
+	{
+		for(int i = 0; i < Num; ++i)
+		{
+			m_aVertices[m_NumVertices + 4*i].m_Pos.x = pArray[i].m_X0;
+			m_aVertices[m_NumVertices + 4*i].m_Pos.y = pArray[i].m_Y0;
+			m_aVertices[m_NumVertices + 4*i].m_Tex = m_aTexture[0];
+			m_aVertices[m_NumVertices + 4*i].m_Color = m_aColor[0];
 
-	AddVertices(4*Num);
+			m_aVertices[m_NumVertices + 4*i + 1].m_Pos.x = pArray[i].m_X1;
+			m_aVertices[m_NumVertices + 4*i + 1].m_Pos.y = pArray[i].m_Y1;
+			m_aVertices[m_NumVertices + 4*i + 1].m_Tex = m_aTexture[1];
+			m_aVertices[m_NumVertices + 4*i + 1].m_Color = m_aColor[1];
+
+			m_aVertices[m_NumVertices + 4*i + 2].m_Pos.x = pArray[i].m_X3;
+			m_aVertices[m_NumVertices + 4*i + 2].m_Pos.y = pArray[i].m_Y3;
+			m_aVertices[m_NumVertices + 4*i + 2].m_Tex = m_aTexture[3];
+			m_aVertices[m_NumVertices + 4*i + 2].m_Color = m_aColor[3];
+
+			m_aVertices[m_NumVertices + 4*i + 3].m_Pos.x = pArray[i].m_X2;
+			m_aVertices[m_NumVertices + 4*i + 3].m_Pos.y = pArray[i].m_Y2;
+			m_aVertices[m_NumVertices + 4*i + 3].m_Tex = m_aTexture[2];
+			m_aVertices[m_NumVertices + 4*i + 3].m_Color = m_aColor[2];
+		}
+
+		AddVertices(4*Num);
+	}
 }
 
 void CGraphics_Threaded::QuadsText(float x, float y, float Size, const char *pText)

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -105,6 +105,7 @@ public:
 		PRIMTYPE_INVALID = 0,
 		PRIMTYPE_LINES,	
 		PRIMTYPE_QUADS,
+		PRIMTYPE_TRIANGLES,
 	};
 
 	enum
@@ -363,7 +364,7 @@ class CGraphics_Threaded : public IEngineGraphics
 
 	void FlushVertices();
 	void AddVertices(int Count);
-	void Rotate4(const CCommandBuffer::SPoint &rCenter, CCommandBuffer::SVertex *pPoints);
+	void Rotate(const CCommandBuffer::SPoint &rCenter, CCommandBuffer::SVertex *pPoints, int NumPoints);
 
 	void KickCommandBuffer();
 


### PR DESCRIPTION
This will *maybe* fix #177 or rather improves performance of `gfx_quads_as_triangles`. Should be hopefully now more or less equal to the standard approach.

Tests appreciated

Not sure how the quads should be converted into a triangle strip, using AMD gpu and splited the quad to fit the AMD driver