### PR TITLE
resend player/dummy info that filtered the server

### DIFF
--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -108,7 +108,8 @@ class CGameClient : public IGameClient
 	int m_PredictedTick;
 	int m_LastNewPredictedTick[2];
 
-	int64 m_LastSendInfo;
+	int m_CheckInfo;
+	int m_CheckDummyInfo;
 
 	static void ConTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConKill(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
This replaces the old m_LastSendInfo feature which was only working for the player. Now i cleaned this up. Following works for player and dummy:

When info like player name or skin color changes a variable will be set so after 1 second the client will check if the info changed or if it was filtered by the server spam filter. If it was filtered the info will be send again and after 1 second will be checked again if it changed. So if you change your name two times quickly the client will send the second name every second until it changed on the server.