### PR TITLE
Add a kill_dummy command to "respawn/selfkill" the dummy

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -159,6 +159,14 @@ public:
 		return SendMsg(&Packer, Flags);
 	}
 
+    template<class T>
+	int SendPackMsgExY(T *pMsg, int Flags, int ClientID)
+	{
+		CMsgPacker Packer(pMsg->MsgID());
+		if(pMsg->Pack(&Packer))
+			return -1;
+		return SendMsgExY(&Packer, Flags, false, ClientID);
+	}
 	//
 	virtual const char *ErrorString() = 0;
 	virtual const char *LatestVersion() = 0;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -207,6 +207,7 @@ void CGameClient::OnConsoleInit()
 	// add the some console commands
 	Console()->Register("team", "i", CFGFLAG_CLIENT, ConTeam, this, "Switch team");
 	Console()->Register("kill", "", CFGFLAG_CLIENT, ConKill, this, "Kill yourself");
+    Console()->Register("kill_dummy", "", CFGFLAG_CLIENT, ConKillDummy, this, "Kill your dummy");
 
 	// register server dummy commands for tab completion
 	Console()->Register("tune", "si", CFGFLAG_SERVER, 0, 0, "Tune variable to value");
@@ -1777,7 +1778,7 @@ void CGameClient::SendDummyInfo(bool Start)
 void CGameClient::SendKill(int ClientID)
 {
 	CNetMsg_Cl_Kill Msg;
-	Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);
+    Client()->SendPackMsgExY(&Msg, MSGFLAG_VITAL, ClientID);
 
 	if(g_Config.m_ClDummyCopyMoves)
 	{
@@ -1793,7 +1794,12 @@ void CGameClient::ConTeam(IConsole::IResult *pResult, void *pUserData)
 
 void CGameClient::ConKill(IConsole::IResult *pResult, void *pUserData)
 {
-	((CGameClient*)pUserData)->SendKill(-1);
+	((CGameClient*)pUserData)->SendKill(g_Config.m_ClDummy);
+}
+
+void CGameClient::ConKillDummy(IConsole::IResult *pResult, void *pUserData)
+{
+	((CGameClient*)pUserData)->SendKill(!g_Config.m_ClDummy);
 }
 
 void CGameClient::ConchainSpecialInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -112,6 +112,7 @@ class CGameClient : public IGameClient
 
 	static void ConTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConKill(IConsole::IResult *pResult, void *pUserData);
+    static void ConKillDummy(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConchainSpecialInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSpecialDummyInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
@@ -371,14 +372,14 @@ inline vec3 RgbToHsl(vec3 RGB)
 
 		if (HSL.l < 0.5)
 			HSL.s = (maxColor - minColor) / (maxColor + minColor);
-		else 
+		else
 			HSL.s = (maxColor - minColor) / (2.0 - maxColor - minColor);
 
 		if (RGB.r == maxColor)
 			HSL.h = (RGB.g - RGB.b) / (maxColor - minColor);
 		else if (RGB.g == maxColor)
 			HSL.h = 2.0 + (RGB.b - RGB.r) / (maxColor - minColor);
-		else 
+		else
 			HSL.h = 4.0 + (RGB.r - RGB.g) / (maxColor - minColor);
 
 		HSL.h /= 6; //to bring it to a number between 0 and 1


### PR DESCRIPTION
I saw that CGameClient::SendKill() has a unused argument "int ClientID", it gave me the idea to add a kill_dummy command.