### PR TITLE
(antiping) improve prediction of collision between players

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1568,14 +1568,37 @@ void CGameClient::OnPredict()
 		}
 
 		// move all players and quantize their data
-		for(int c = 0; c < MAX_CLIENTS; c++)
-		{
-			if(!World.m_apCharacters[c])
-				continue;
-
-			World.m_apCharacters[c]->Move();
-			World.m_apCharacters[c]->Quantize();
-		}
+        if(g_Config.m_ClAntiPingPlayers)
+        {
+            for(int h = 0; h < 3; h++)
+            {
+                if(h == 1)
+                {
+                    if(World.m_apCharacters[m_Snap.m_LocalClientID])
+                    {
+                        World.m_apCharacters[m_Snap.m_LocalClientID]->Move();
+                        World.m_apCharacters[m_Snap.m_LocalClientID]->Quantize();
+                    }
+                }
+                else
+                    for(int c = 0; c < MAX_CLIENTS; c++)
+                        if(c != m_Snap.m_LocalClientID && World.m_apCharacters[c] && ((h == 0 && IsWeaker[g_Config.m_ClDummy][c]) || (h == 2 && !IsWeaker[g_Config.m_ClDummy][c])))
+                        {
+                            World.m_apCharacters[c]->Move();
+                            World.m_apCharacters[c]->Quantize();
+                        }
+            }
+        }
+        else
+        {
+            for(int c = 0; c < MAX_CLIENTS; c++)
+            {
+                if(!World.m_apCharacters[c])
+                    continue;
+                World.m_apCharacters[c]->Move();
+                World.m_apCharacters[c]->Quantize();
+            }
+        }
 
 		// check if we want to trigger effects
 		if(Tick > m_LastNewPredictedTick[g_Config.m_ClDummy])


### PR DESCRIPTION
With this code it seems like rocket fly with dummy is perfectly or at least much better predicted (with antiping enabled).

It works by running the collision code for each player in (approximately) the same order as the server does. It is only a modification of the hook strength prediction patch, and the difference is that it the previous code was only applied to Tick(), while this applies the code to Move() and Quantize() of the charactercore as well.