### PR TITLE
[Feature Request] Add dynamic camera console toggle feature

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -85,6 +85,7 @@ void CCamera::OnConsoleInit()
 	Console()->Register("zoom+", "", CFGFLAG_CLIENT, ConZoomPlus, this, "Zoom increase");
 	Console()->Register("zoom-", "", CFGFLAG_CLIENT, ConZoomMinus, this, "Zoom decrease");
 	Console()->Register("zoom", "", CFGFLAG_CLIENT, ConZoomReset, this, "Zoom reset");
+	Console()->Register("toggle_dynamic_camera", "", CFGFLAG_CLIENT, ConToggleDynamic, this, "Turn dynamic camera on/off");
 }
 
 const float ZoomStep = 0.866025f;
@@ -125,4 +126,25 @@ void CCamera::ConZoomReset(IConsole::IResult *pResult, void *pUserData)
 	CServerInfo Info;
 	pSelf->Client()->GetServerInfo(&Info);
 	((CCamera *)pUserData)->OnReset();
+}
+
+void CCamera::ToggleDynamic()
+{
+	if(g_Config.m_ClMouseDeadzone)
+	{
+		g_Config.m_ClMouseFollowfactor = 0;
+		g_Config.m_ClMouseMaxDistance = 400;
+		g_Config.m_ClMouseDeadzone = 0;
+	}
+	else
+	{
+		g_Config.m_ClMouseFollowfactor = g_Config.m_DynCamFollowFactor;
+		g_Config.m_ClMouseMaxDistance = g_Config.m_DynCamMaxDistance;
+		g_Config.m_ClMouseDeadzone = g_Config.m_DynCamDeadZone;
+	}
+}
+
+void CCamera::ConToggleDynamic(IConsole::IResult *pResult, void *pUserData)
+{
+	ToggleDynamic();
 }

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -30,10 +30,13 @@ public:
 
 	virtual void OnConsoleInit();
 	virtual void OnReset();
+
+	static void ToggleDynamic();
 private:
 	static void ConZoomPlus(IConsole::IResult *pResult, void *pUserData);
 	static void ConZoomMinus(IConsole::IResult *pResult, void *pUserData);
 	static void ConZoomReset(IConsole::IResult *pResult, void *pUserData);
+	static void ConToggleDynamic(IConsole::IResult *pResult, void *pUserData);
 };
 
 #endif

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -24,6 +24,7 @@
 #include <game/localization.h>
 
 #include "binds.h"
+#include "camera.h"
 #include "countryflags.h"
 #include "menus.h"
 #include "skins.h"
@@ -74,18 +75,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		static int s_DynamicCameraButton = 0;
 		if(DoButton_CheckBox(&s_DynamicCameraButton, Localize("Dynamic Camera"), g_Config.m_ClMouseDeadzone != 0, &Button))
 		{
-			if(g_Config.m_ClMouseDeadzone)
-			{
-				g_Config.m_ClMouseFollowfactor = 0;
-				g_Config.m_ClMouseMaxDistance = 400;
-				g_Config.m_ClMouseDeadzone = 0;
-			}
-			else
-			{
-				g_Config.m_ClMouseFollowfactor = 60;
-				g_Config.m_ClMouseMaxDistance = 1000;
-				g_Config.m_ClMouseDeadzone = 300;
-			}
+			CCamera::ToggleDynamic();
 		}
 
 		// weapon pickup

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -49,6 +49,10 @@ MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 400, 0, 0, CFGFLAG_C
 MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 800, 0, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
 #endif
 
+MACRO_CONFIG_INT(DynCamMaxDistance, cl_dyn_cam_max_distance, 1000, 0, 2000, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Maximal dynamic camera distance")
+MACRO_CONFIG_INT(DynCamDeadZone, cl_dyn_cam_dead_zone, 300, 1, 1300, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Dynamic camera dead zone")
+MACRO_CONFIG_INT(DynCamFollowFactor, cl_dyn_cam_follow_factor, 60, 0, 200, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Dynamic camera follow factor")
+
 MACRO_CONFIG_INT(EdZoomTarget, ed_zoom_target, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Zoom to the current mouse target")
 MACRO_CONFIG_INT(EdShowkeys, ed_showkeys, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
 


### PR DESCRIPTION
Hi.

During my play time on (mostly) vanilla and DDRace I occasionaly need to have
further vision without enabling dynamic camera, which is now tedious and is
performed in menu only.

The feature I need is to toggle dynamic camera via binds to allow for quick
switches between extended and normal vision without harming my close-range aim
which happens when I always have dynamic camera on.

I have implemented this feature myself and so I would be grateful if you could
review the code and maybe accept it into your branch.

Dynamic camera can now be bound to key with this command: bind <key>
toggle_dynamic_camera.

For now I have concerns on whether I did it right expanding variables.h with
dyn cam variables, changing which seems to have little effect in game.

Thanks in advance!
