### PR TITLE
Dyncam saves mousesens. Closes #250

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -130,17 +130,27 @@ void CCamera::ConZoomReset(IConsole::IResult *pResult, void *pUserData)
 
 void CCamera::ToggleDynamic()
 {
+	static int s_OldMousesens = 0;
 	if(g_Config.m_ClMouseDeadzone)
 	{
 		g_Config.m_ClMouseFollowfactor = 0;
 		g_Config.m_ClMouseMaxDistance = g_Config.m_DefaultMouseMaxDistance;
 		g_Config.m_ClMouseDeadzone = 0;
+		if(g_Config.m_ClDynCamMousesens)
+		{
+			g_Config.m_InpMousesens = s_OldMousesens;
+		}
 	}
 	else
 	{
+		s_OldMousesens = g_Config.m_InpMousesens;
 		g_Config.m_ClMouseFollowfactor = g_Config.m_DynCamFollowFactor;
 		g_Config.m_ClMouseMaxDistance = g_Config.m_DynCamMaxDistance;
 		g_Config.m_ClMouseDeadzone = g_Config.m_DynCamDeadZone;
+		if(g_Config.m_ClDynCamMousesens)
+		{
+			g_Config.m_InpMousesens = g_Config.m_ClDynCamMousesens;
+		}
 	}
 }
 

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -136,7 +136,7 @@ void CCamera::ToggleDynamic()
 		g_Config.m_ClMouseFollowfactor = 0;
 		g_Config.m_ClMouseMaxDistance = g_Config.m_DefaultMouseMaxDistance;
 		g_Config.m_ClMouseDeadzone = 0;
-		if(g_Config.m_ClDynCamMousesens)
+		if(g_Config.m_ClDynCamMousesens && s_OldMousesens)
 		{
 			g_Config.m_InpMousesens = s_OldMousesens;
 		}

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -54,6 +54,7 @@ MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 800, 0, 0, CFGFLAG_C
 
 MACRO_CONFIG_INT(DynCamMaxDistance, cl_dyn_cam_max_distance, 1000, 0, 2000, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Maximal dynamic camera distance")
 MACRO_CONFIG_INT(DefaultMouseMaxDistance, cl_default_mouse_max_distance, 400, 0, 2000, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Default mouse max distance. Dyncam switches back to it")
+MACRO_CONFIG_INT(ClDynCamMousesens, cl_dyn_cam_mouse_sens, 0, 5, 100000, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Mouse sens used when dyncam is toggled on")
 MACRO_CONFIG_INT(DynCamDeadZone, cl_dyn_cam_dead_zone, 300, 1, 1300, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Dynamic camera dead zone")
 MACRO_CONFIG_INT(DynCamFollowFactor, cl_dyn_cam_follow_factor, 60, 0, 200, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Dynamic camera follow factor")
 


### PR DESCRIPTION
This PR closes #250 

A feature I wanted too, but forgot to implement it eventually.

New config variable was introduced, g_Config.m_ClDynCamMousesens. If client sets this variable then it will be used as InpMousesens when client toggles dyncam.
Otherwise it's ignored.